### PR TITLE
Fix Xcode 8.3 warning

### DIFF
--- a/FastImageCache/FastImageCache/FastImageCache/FICUtilities.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICUtilities.m
@@ -41,7 +41,7 @@ NSString * FICStringWithUUIDBytes(CFUUIDBytes UUIDBytes) {
 }
 
 CFUUIDBytes FICUUIDBytesWithString(NSString *string) {
-    CFUUIDBytes UUIDBytes;
+    CFUUIDBytes UUIDBytes = {0};
     CFUUIDRef UUIDRef = CFUUIDCreateFromString(kCFAllocatorDefault, (CFStringRef)string);
     
     if (UUIDRef != NULL) {


### PR DESCRIPTION
By initializing CFUUIDBytes struct